### PR TITLE
Hs 49 따옴표 제거 토큰 파서로 수정하기

### DIFF
--- a/src/parser/make_arr_to_list.c
+++ b/src/parser/make_arr_to_list.c
@@ -52,7 +52,7 @@ static void	insert_str_into_list_back(t_token **lst, char *str)
 	(*lst) = (*lst)->next;
 }
 
-static void	set_str_into_list(t_token **lst, char **str)
+static int	set_str_into_list(t_token **lst, char **str)
 {
 	int		i;
 
@@ -67,6 +67,7 @@ static void	set_str_into_list(t_token **lst, char **str)
 	}
 	free(str);
 	str = NULL;
+	return (1);
 }
 
 t_token	*set_token_list(char **token_arr)
@@ -75,7 +76,9 @@ t_token	*set_token_list(char **token_arr)
 
 	if (!token_arr || !*token_arr)
 		exit(EXIT_FAILURE);
-	set_str_into_list(&token_list_head, token_arr);
-	token_list_head = get_token_head(token_list_head);
+	if (set_str_into_list(&token_list_head, token_arr))
+		token_list_head = get_token_head(token_list_head);
+	else
+		return (0);
 	return (token_list_head);
 }

--- a/src/utils/ft_split.c
+++ b/src/utils/ft_split.c
@@ -24,6 +24,7 @@ char	**command_split(char *str)
 	int		split_size;
 	char	**result;
 
+	// split free
 	if (!str)
 		return (NULL);
 	result = NULL;

--- a/src/utils/ft_split_util.c
+++ b/src/utils/ft_split_util.c
@@ -1,5 +1,20 @@
 #include "../../include/minishell.h"
 
+void	handle_quote(char *line, int *count, int *idx)
+{
+	int	qoute_num;
+
+	qoute_num = line[*idx];
+	(*idx)++;
+	while (line[*idx] != qoute_num)
+	{
+		if (line[*idx] == '\0')
+			exit(EXIT_FAILURE);
+		(*count)++;
+		(*idx)++;
+	}
+}
+
 int	check_white_space(char c)
 {
 	if ((c >= 9 && c <= 13) || c == 32)
@@ -42,6 +57,11 @@ int	split_line(char *line, char **str, int *i)
 	}
 	while (!check_white_space(line[*i]) && line[*i] != '\0')
 	{
+		if (line[*i] == 34 || line[*i] == 39)
+		{
+			handle_quote(line, &rtn, i);
+			break ;
+		}
 		rtn++;
 		(*i)++;
 	}

--- a/src/utils/ft_split_util.c
+++ b/src/utils/ft_split_util.c
@@ -80,6 +80,23 @@ int	split_line(char *line, char **str, int *i)
 	(*str) = malloc(sizeof(char) * rtn + 1);
 	if (!(*str))
 		exit(EXIT_FAILURE);
-	ft_strlcpy((*str), line + (*i) - rtn, rtn + 1);
+	// line, 0부터 쿼트 뺴고 넣기
+	int	z;
+	int	j;
+
+	z = 0;
+	j = 0;
+	while (z < rtn)
+	{
+		if (line[j] == '\'' || line[j] == '\"')
+			j++;
+		else
+		{
+			(*str)[z] = line[j];
+			z++;
+			j++;
+		}
+	}
+	(*str)[z] = '\0';
 	return (rtn);
 }

--- a/src/utils/ft_split_util.c
+++ b/src/utils/ft_split_util.c
@@ -3,7 +3,24 @@
 int	handle_quote(char *line, int *count, int *idx)
 {
 	int	quotes;
+	int	i;
+	int	single_quotes;
+	int	double_quotes;
 
+	// 홀수 체크 check_odd_quotes(line)
+	i = 0;
+	single_quotes = 0;
+	double_quotes = 0;
+	while (line[i])
+	{
+		if (line[i] == '\'')
+			single_quotes++;
+		else if (line[i] == '\"')
+			double_quotes++;
+		i++;
+	}
+	if ((single_quotes % 2) || (double_quotes % 2))
+		return (0);
 	while (line[*idx] != '\0')
 	{
 		// "abc"de
@@ -12,16 +29,15 @@ int	handle_quote(char *line, int *count, int *idx)
 			quotes = line[*idx];
 			(*idx)++;
 		}
-		while ((quotes != line[*idx]) && ft_isalnum(line[*idx])) // 따옴표 확인
+		while ((line[*idx] != '\'' || line[*idx] != '\"') && ft_isalnum(line[*idx])) // 따옴표 확인
 		{
 			(*idx)++;
 			(*count)++;
+			if ((line[*idx] == '\'' || line[*idx] == '\"'))
+				quotes = line[*idx];
 		}
-		// 큰따옴표에서 작은따옴표로 바뀔 때 quote는 큰따옴표로 기억하기 때문에 에러가남
-		// 음... 바로 위의 while문에 quote를 확인하고 변경하는 게 어떨까?
-		// 공백 처리까지 해야함
 		if ((quotes != line[*idx]) && (line[*idx] != '\0'))
-			return (1); //ft_error 로 바꿔야함.
+			return (1);
 		else if (line[*idx] == '\0')
 			return (0);
 		(*idx)++;

--- a/src/utils/ft_split_util.c
+++ b/src/utils/ft_split_util.c
@@ -12,8 +12,22 @@ void	handle_quote(char *line, int *count, int *idx)
 		// qoute_num 도 바꿀 것
 		if (line[*idx] == '\0')
 			exit(EXIT_FAILURE);
-		(*count)++;
-		(*idx)++;
+		if (line[(*idx) + 1] == qoute_num)
+		{
+			if (ft_isalnum(line[(*idx) + 2]))
+			{
+				;
+			}
+			else if (line[(*idx) + 2] == '\"' || line[(*idx) + 2] == '\'' )
+			{
+				;
+			}
+		}
+		else
+		{
+			(*count)++;
+			(*idx)++;
+		}
 	}
 }
 

--- a/src/utils/ft_split_util.c
+++ b/src/utils/ft_split_util.c
@@ -29,7 +29,9 @@ int	handle_quote(char *line, int *count, int *idx)
 			quotes = line[*idx];
 			(*idx)++;
 		}
-		while ((line[*idx] != '\'' || line[*idx] != '\"') && ft_isalnum(line[*idx])) // 따옴표 확인
+		while ((line[*idx] != '\'' || line[*idx] != '\"')
+				&& (ft_isalnum(line[*idx]) || (line[*idx] >= 9 && line[*idx] <= 13)
+				|| line[*idx] == 32) ) // 따옴표 확인
 		{
 			(*idx)++;
 			(*count)++;

--- a/src/utils/ft_split_util.c
+++ b/src/utils/ft_split_util.c
@@ -8,6 +8,8 @@ void	handle_quote(char *line, int *count, int *idx)
 	(*idx)++;
 	while (line[*idx] != qoute_num)
 	{
+		//조건 추가 - 뒤에 쿼트있는지(싱글, 더블)
+		// qoute_num 도 바꿀 것
 		if (line[*idx] == '\0')
 			exit(EXIT_FAILURE);
 		(*count)++;

--- a/src/utils/ft_split_util.c
+++ b/src/utils/ft_split_util.c
@@ -7,16 +7,19 @@ int	handle_quote(char *line, int *count, int *idx)
 	while (line[*idx] != '\0')
 	{
 		// "abc"de
-		if (line[*idx] == 34 || line[*idx] == 39)
+		if (line[*idx] == '\'' || line[*idx] == '\"')
 		{
 			quotes = line[*idx];
 			(*idx)++;
 		}
-		while ((line[*idx] != 34 || line[*idx] != 39) && ft_isalnum(line[*idx])) // 따옴표 확인
+		while ((quotes != line[*idx]) && ft_isalnum(line[*idx])) // 따옴표 확인
 		{
 			(*idx)++;
 			(*count)++;
 		}
+		// 큰따옴표에서 작은따옴표로 바뀔 때 quote는 큰따옴표로 기억하기 때문에 에러가남
+		// 음... 바로 위의 while문에 quote를 확인하고 변경하는 게 어떨까?
+		// 공백 처리까지 해야함
 		if ((quotes != line[*idx]) && (line[*idx] != '\0'))
 			return (1); //ft_error 로 바꿔야함.
 		else if (line[*idx] == '\0')

--- a/src/utils/ft_split_util.c
+++ b/src/utils/ft_split_util.c
@@ -1,34 +1,29 @@
 #include "../../include/minishell.h"
 
-void	handle_quote(char *line, int *count, int *idx)
+int	handle_quote(char *line, int *count, int *idx)
 {
-	int	qoute_num;
+	int	quotes;
 
-	qoute_num = line[*idx];
-	(*idx)++;
-	while (line[*idx] != qoute_num)
+	while (line[*idx] != '\0')
 	{
-		//조건 추가 - 뒤에 쿼트있는지(싱글, 더블)
-		// qoute_num 도 바꿀 것
-		if (line[*idx] == '\0')
-			exit(EXIT_FAILURE);
-		if (line[(*idx) + 1] == qoute_num)
+		// "abc"de
+		if (line[*idx] == 34 || line[*idx] == 39)
 		{
-			if (ft_isalnum(line[(*idx) + 2]))
-			{
-				;
-			}
-			else if (line[(*idx) + 2] == '\"' || line[(*idx) + 2] == '\'' )
-			{
-				;
-			}
-		}
-		else
-		{
-			(*count)++;
+			quotes = line[*idx];
 			(*idx)++;
 		}
+		while ((line[*idx] != 34 || line[*idx] != 39) && ft_isalnum(line[*idx])) // 따옴표 확인
+		{
+			(*idx)++;
+			(*count)++;
+		}
+		if ((quotes != line[*idx]) && (line[*idx] != '\0'))
+			return (1); //ft_error 로 바꿔야함.
+		else if (line[*idx] == '\0')
+			return (0);
+		(*idx)++;
 	}
+	return (0);
 }
 
 int	check_white_space(char c)
@@ -75,7 +70,8 @@ int	split_line(char *line, char **str, int *i)
 	{
 		if (line[*i] == 34 || line[*i] == 39)
 		{
-			handle_quote(line, &rtn, i);
+			if (handle_quote(line, &rtn, i))
+				return (0);
 			break ;
 		}
 		rtn++;

--- a/test/built_in_unit_test.c
+++ b/test/built_in_unit_test.c
@@ -2,11 +2,11 @@
 
 int	main(void)
 {
-	// printf("\n %s: ft_exit unit test : %s \n", MAG, COLOR_RESET);
-	// ft_exit(3);
+	printf("\n %s: ft_exit unit test : %s \n", MAG, COLOR_RESET);
+	ft_exit(7, "");
 
-	printf("\n %s: ft_pwd unit test : %s \n", MAG, COLOR_RESET);
-	ft_pwd();
+	// printf("\n %s: ft_pwd unit test : %s \n", MAG, COLOR_RESET);
+	// ft_pwd();
 
 	// printf("\n %s: ft_env unit test : %s \n", MAG, COLOR_RESET);
 	// ft_env(someting args);


### PR DESCRIPTION
### 요약
렉서에서 따옴표 처리
따옴표는 작은 따옴표, 큰따옴표를 얘기합니다.

### 작업 사항

* 따옴표
ex. "abc"

* 연속으로 따옴표
ex. "abc"'de'"ss"

* 따옴표 안에 공백
ex. "ab c"de"fg"

* 따옴표 뒤에 문자열
ex. "ddssgg"sdf


### 스크린샷 (optional)
<img width="269" alt="image" src="https://user-images.githubusercontent.com/85930183/182526189-96e74871-b879-40cc-bfda-7539aa49493d.png">