### PR TITLE
HS-60 FIX : process 구조체 변경

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,9 @@ SRC = ./src/main.c ./src/welcome/print_wallpaper.c \
 ./src/utils/env.c ./src/utils/init.c ./src/utils/is_same_string.c ./src/utils/get_token_head.c \
 ./src/utils/signal.c ./src/utils/safe_malloc.c \
 ./src/built_in/ft_exit.c ./src/built_in/ft_env.c ./src/built_in/ft_export.c\
-./src/parser/make_arr_to_list.c ./src/parser/set_process_list.c ./src/temp_tester/command_list_test.c
+./src/parser/make_arr_to_list.c ./src/parser/set_process_list.c  ./src/parser/process_list_utils.c \
+./src/parser/process_utils.c \
+./src/temp_tester/command_list_test.c
 
 OBJ=$(SRC:.c=.o)
 

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -43,10 +43,9 @@ typedef struct s_token
 
 typedef struct s_process
 {
+	char	*argv;
+	int		argc;
 	t_token	*head;
-	t_token	*command;
-	t_token	*prefix;
-	t_token	*suffix;
 }	t_process;
 
 typedef struct s_pslist
@@ -95,6 +94,13 @@ void	get_new_prompt(int sig);
 
 /* parser */
 void	set_command_list(t_pslist **ps_list, t_token *tk_lst);
+int		count_pipe(t_token *tk_list);
+void	init_pslist(t_pslist **lst, int cnt);
+void	pslist_new(t_pslist **lst);
+void	pslist_addback(t_pslist **lst);
+void	init_process_struct(t_process **cmd_list);
+void	cut_tail_by_pipe(t_token **tk_list);
+void	tk_listdelone(t_token **tk_list);
 
 /* temp tester!
 delete this before submit */

--- a/src/parser/process_list_utils.c
+++ b/src/parser/process_list_utils.c
@@ -1,0 +1,64 @@
+#include "../../include/minishell.h"
+
+int count_pipe(t_token *tk_list)
+{
+	t_token	*curr;
+	int		cnt;
+
+	curr = tk_list;
+	cnt = 0;
+	while (curr)
+	{
+		if (*(curr->value) == '|')
+			cnt++;
+		curr = curr->next;
+	}
+	return (cnt);
+}
+
+void init_pslist(t_pslist **lst, int cnt)
+{
+	int	i;
+
+	i = 0;
+	while (i <= cnt)
+	{
+		if (i == 0)
+			pslist_new(lst);
+		else
+			pslist_addback(lst);
+		i++;
+	}
+}
+
+void pslist_new(t_pslist **lst)
+{
+	t_pslist	*list_temp;
+	t_process	*ps_temp;
+
+	list_temp = safe_malloc(sizeof(t_pslist *));
+	init_process_struct(&ps_temp);
+	list_temp->value = ps_temp;
+	list_temp->next = NULL;
+	list_temp->prev = NULL;
+	(*lst) = list_temp;
+}
+
+void pslist_addback(t_pslist **lst)
+{
+	t_pslist	*list_temp;
+	t_pslist	*lst_idx;
+	t_process	*ps_temp;
+
+	lst_idx = *lst;
+	list_temp = safe_malloc(sizeof(t_pslist *));
+	init_process_struct(&ps_temp);
+	while (lst_idx->next)
+	{
+		lst_idx = lst_idx->next;
+	}
+	list_temp->value = ps_temp;
+	list_temp->next = NULL;
+	list_temp->prev = lst_idx;
+	lst_idx->next = list_temp;
+}

--- a/src/parser/process_utils.c
+++ b/src/parser/process_utils.c
@@ -1,0 +1,35 @@
+#include "../../include/minishell.h"
+
+void init_process_struct(t_process **cmd_list)
+{
+	t_process *temp;
+
+	temp = safe_malloc(sizeof(t_process *));
+	temp->head = NULL;
+	temp->argc = 0;
+	temp->argv = NULL;
+	(*cmd_list) = temp;
+}
+
+void cut_tail_by_pipe(t_token **tk_list)
+{
+	t_token	*curr;
+
+	curr = *tk_list;
+	while (*(curr->next->value) != '|')
+		curr = curr->next;
+	curr->next->prev = NULL;
+	curr->next = NULL;
+}
+
+void tk_listdelone(t_token **tk_list)
+{
+	if ((*tk_list)->prev)
+		(*tk_list)->prev->next = (*tk_list)->next;
+	if ((*tk_list)->next)
+		(*tk_list)->next->prev = (*tk_list)->prev;
+	(*tk_list)->prev = NULL;
+	(*tk_list)->next = NULL;
+	free(*tk_list);
+	(*tk_list) = NULL;
+}

--- a/src/parser/set_process_list.c
+++ b/src/parser/set_process_list.c
@@ -1,114 +1,5 @@
 #include "../../include/minishell.h"
 
-static void init_process_struct(t_process **cmd_list)
-{
-	t_process *temp;
-
-	temp = safe_malloc(sizeof(t_process *));
-	temp->head = NULL;
-	temp->command = NULL;
-	temp->prefix = NULL;
-	temp->suffix = NULL;
-	(*cmd_list) = temp;
-}
-
-static int count_pipe(t_token *tk_list)
-{
-	t_token	*curr;
-	int		cnt;
-
-	curr = tk_list;
-	cnt = 0;
-	while (curr)
-	{
-		if (*(curr->value) == '|')
-			cnt++;
-		curr = curr->next;
-	}
-	return (cnt);
-}
-
-static void pslist_new(t_pslist **lst)
-{
-	t_pslist	*list_temp;
-	t_process	*ps_temp;
-
-	list_temp = safe_malloc(sizeof(t_pslist *));
-	init_process_struct(&ps_temp);
-	list_temp->value = ps_temp;
-	list_temp->next = NULL;
-	list_temp->prev = NULL;
-	(*lst) = list_temp;
-}
-
-static void pslist_addback(t_pslist **lst)
-{
-	t_pslist	*list_temp;
-	t_pslist	*lst_idx;
-	t_process	*ps_temp;
-
-	lst_idx = *lst;
-	list_temp = safe_malloc(sizeof(t_pslist *));
-	init_process_struct(&ps_temp);
-	while (lst_idx->next)
-	{
-		lst_idx = lst_idx->next;
-	}
-	list_temp->value = ps_temp;
-	list_temp->next = NULL;
-	list_temp->prev = lst_idx;
-	lst_idx->next = list_temp;
-}
-
-static void init_pslist(t_pslist **lst, int cnt)
-{
-	int	i;
-
-	i = 0;
-	while (i <= cnt)
-	{
-		if (i == 0)
-			pslist_new(lst);
-		else
-			pslist_addback(lst);
-		i++;
-	}
-}
-
-static void cut_tail_by_pipe(t_token **tk_list)
-{
-	t_token	*curr;
-
-	curr = *tk_list;
-	while (*(curr->next->value) != '|')
-		curr = curr->next;
-	curr->next->prev = NULL;
-	curr->next = NULL;
-}
-
-static void tk_listdelone(t_token **tk_list)
-{
-	if ((*tk_list)->prev)
-		(*tk_list)->prev->next = (*tk_list)->next;
-	if ((*tk_list)->next)
-		(*tk_list)->next->prev = (*tk_list)->prev;
-	(*tk_list)->prev = NULL;
-	(*tk_list)->next = NULL;
-	free(*tk_list);
-	(*tk_list) = NULL;
-}
-
-static void cut_tail_by_cmd(t_token **tk_list)
-{
-	t_token	*curr;
-
-	curr = *tk_list;
-	while (curr->type != TK_CMD)
-		curr = curr->next;
-	curr->next->prev = NULL;
-	curr->next = NULL;
-}
-
 static void insert_command_head(t_pslist **ps_list, t_token *tk_list)
 {
 	t_pslist	*pslist_curr;
@@ -137,59 +28,13 @@ static void insert_command_head(t_pslist **ps_list, t_token *tk_list)
 	}
 }
 
-static t_token *cut_link_token(t_token *tk_list)
-{
-	t_token *rtn_token;
-
-	rtn_token = tk_list;
-	if (rtn_token->prev)
-		rtn_token->prev->next = NULL;
-	rtn_token->prev = NULL;
-	if (rtn_token->next)
-		rtn_token->next->prev = NULL;
-	rtn_token->next = NULL;
-	return (rtn_token);
-}
-
-void insert_process_info(t_pslist	**ps_list)
-{
-	t_pslist	*pslist_curr;
-	t_token		*token_head;
-	t_token		*token_curr;
-	t_token		*command;
-
-	pslist_curr = *ps_list;
-	token_curr = pslist_curr->value->head;
-	while (pslist_curr)
-	{
-		token_head = token_curr;
-		while (token_curr && token_curr->type != TK_CMD)
-			token_curr = token_curr->next;
-		if (token_curr && token_curr->type == TK_CMD)
-		{
-			if (token_curr != token_head)
-			{
-				pslist_curr->value->prefix = token_head;
-				cut_tail_by_cmd(&(pslist_curr->value->prefix));
-			}
-			command = token_curr;
-			token_curr = token_curr->next;
-			pslist_curr->value->command = cut_link_token(command);
-		}
-		else
-			ft_error_exit("no command!");
-		pslist_curr->value->suffix = token_curr;
-		pslist_curr = pslist_curr->next;
-	}
-}
 
 void set_command_list(t_pslist	**ps_list, t_token *tk_list)
 {
 	int			pipe_cnt;
 
 	pipe_cnt = count_pipe(tk_list);
-	printf("pipe count: %d\n", pipe_cnt);
 	init_pslist(ps_list, pipe_cnt);
 	insert_command_head(ps_list, tk_list);
-	// command_list_tester(*ps_list);
+	command_list_tester(*ps_list);
 }


### PR DESCRIPTION
### 현잔님 코드 참고

더 이상 구조체를 바꾸지 않기 위해서 현잔님 코드를 분석했습니다. 주석을 참고 바랍니다.

``` c
typedef struct s_token
{
	int				type;
	char			*str;
	struct s_token	*prev;
	struct s_token	*next;
}	t_token;
// ⬆️ 이건 오케이

typedef struct s_command {
	pid_t				pid;
	/* ⬆️ 각 프로세스의 pid 정보를 넣어둠
	 실제 코드에서도 딱 한 번 쓰이는데, 마지막 프로세스의 pid를 찾을 때 씀
	 필요한지 약간 애매;
	 wait_childs 검색 */
	t_token				*tokens;
	char				**argv;
	/* ⬆️ token list 를 이중 배열로 잘라서 넣는다 (make_argv_list)
        int execve(const char *path, char const *argv[], char *const envp[]);
        의 인자가 char * 이기 때문인 듯!
	*/
	int    argc;  // ⬅️ argv 랑 세트
	int	infile; // ⬅️ 만들어 놓고 안 씀 ㅡ,.ㅡ
	int	outfile; // ⬅️ 만들어 놓고 안 씀 ㅡ,.ㅡ
	int	token_size;  // ⬅️ 두 번 쓰이는데 굳이 없어도 될 듯
	struct s_command	*next;
}	t_command;
// ⬆️ 제 코드에서 process 구조체와 같은 것입니다.

typedef struct s_pipeline {
	t_token	*tokens;
	int		token_size;  // ⬅️ 그냥 세는 함수 만들자 얼마 쓰이지도 않음
	int		seperated_type;  // ⬅️ || && 둘 중 하나의 타입 설정해주는 것 우린 필요 ㄴ
	t_command	*commands;
	struct s_pipeline	*next;
}	t_pipeline;

```

### 작업 사항

우리에게 필요한 것들만 생각해서 만든 것!

```c
typedef struct s_token
{
	int				type;
	char			*value;
	struct s_token	*prev;
	struct s_token	*next;
}	t_token;

typedef struct s_process
{
	char	*argv;
	int		argc;
	t_token	*head;
}	t_process;

typedef struct s_pslist
{
	t_process		*value;
	struct s_pslist	*prev;
	struct s_pslist	*next;
}	t_pslist;
```

@jhMin95  의 의견을 수렴하여, token list는 pipe를 만나면 자릅니다.
따라서 parser 이후로는 token list 사용 금지~