### PR TITLE
HS-63 FEAT: safe_malloc이 초기화도 해줌

### DIFF
--- a/src/utils/safe_malloc.c
+++ b/src/utils/safe_malloc.c
@@ -7,5 +7,6 @@ void *safe_malloc(size_t size)
 	allocated_ptr = malloc(size);
 	if (!allocated_ptr)
 		ft_error_exit("malloc failed");
+	ft_bzero(allocated_ptr, size);
 	return (allocated_ptr);
 }


### PR DESCRIPTION
### 요약
HS-63 FEAT: safe_malloc이 초기화도 해줌

ft_bzero()가 추가됨