### PR TITLE
FIX: 달러뒤에 있는 값들도 문자열에 넣어줌

### DIFF
--- a/src/utils/replace_dollar/replace_dollar.c
+++ b/src/utils/replace_dollar/replace_dollar.c
@@ -91,6 +91,11 @@ char	*replace_whole_input_dollar(char *input, t_minishell *minishell)
 			input_buffer = replace_dollar(input_buffer, input_ptr, minishell);
 			input_ptr += get_env_len(input_ptr);
 		}
+		if (!ft_strchr(input_ptr, '$'))
+		{
+			input_buffer = append_buffer(input_buffer, input_ptr);
+			break ;
+		}
 		input_buffer = append_buffer_under_dollar(input_buffer, input_ptr);
 		input_ptr += (ft_strchr(input_ptr, '$') - input_ptr);
 		if (!input_ptr)


### PR DESCRIPTION
### 요약
  달러치환 버그 픽스

   달러뒤에 문자열이 들어가지 않는 버그를 픽스하였습니다.
   
### 스크린샷 (optional
<img width="332" alt="스크린샷 2022-08-17 오후 12 15 21" src="https://user-images.githubusercontent.com/62806979/185027760-2c726c17-0357-410c-8d27-32e1e3c3c273.png">
