### PR TITLE
HS-91-makefile-warning-없애기

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,13 @@ CFLAGS= -Wall -Wextra -Werror
 # readline 경로를 아키텍쳐 별로 변경하는 코드. M1 Mac, Cluster Mac, arm Linux 환경 대응
 detected_OS := $(shell uname -sm)
 ifeq ($(detected_OS), Linux aarch64)
-#### linux 경로대로 변경
-READLINE = -lreadline 
+LINKING_FLAGS = -lreadline
 else ifeq ($(detected_OS), Darwin x86_64)
-READLINE = -lreadline -L ${HOME}/.brew/opt/readline/lib -I ${HOME}/.brew/opt/readline/include
+LINKING_FLAGS = -lreadline -L ${HOME}/.brew/opt/readline/lib
+COMFILE_FLAGS = -I ${HOME}/.brew/opt/readline/include
 else ifeq ($(detected_OS), Darwin arm64)
-READLINE = -lreadline -L /opt/homebrew/opt/readline/lib -I /opt/homebrew/opt/readline/include
+LINKING_FLAGS = -lreadline -L /opt/homebrew/opt/readline/lib
+COMFILE_FLAGS = -I /opt/homebrew/opt/readline/include
 endif
 
 RM = rm -rf
@@ -50,7 +51,7 @@ OBJS = $(READLINE_OBJS) $(MAIN_OBJS) $(BUILT_IN_OBJS) $(PARSER_OBJS) $(UTILS_OBJ
 $(NAME) : $(OBJS)
 	make bonus -j -C $(LIB_DIR)/libft
 	make -j -C $(LIB_DIR)/get_next_line
-	$(CC) $(CFLAGS) $(OBJS) $(READLINE) $(LIB_DIR)/$(LIBFT) $(LIB_DIR)/$(GNL) -o $(NAME)
+	$(CC) $(CFLAGS) $(OBJS) $(LINKING_FLAGS) $(LIB_DIR)/$(LIBFT) $(LIB_DIR)/$(GNL) -o $(NAME)
 	make -j fclean -C $(LIB_DIR)/libft
 	make -j fclean -C $(LIB_DIR)/get_next_line
 #  -fsanitize=address
@@ -72,6 +73,6 @@ re :
 	make all
 
 %.o :   %.c
-	$(CC) $(READLINE) -c $^ -o $@
+	$(CC) -c $^ $(COMFILE_FLAGS) -o $@
 
 .PHONY : all clean fclean re


### PR DESCRIPTION
### 요약
마참내! warning 이 안 뜹니다
### 작업 
compile flags 와 linking flags 로 분리하고 컴파일할 때, 링킹할 때 분리.

<img width="623" alt="Screen Shot 2022-08-23 at 3 29 22 PM" src="https://user-images.githubusercontent.com/45284810/186086899-e9b8440e-2ebe-44a8-9219-541f2acc52f2.png">
<img width="415" alt="Screen Shot 2022-08-23 at 3 29 50 PM" src="https://user-images.githubusercontent.com/45284810/186086928-3b170c6f-d4c5-43f6-bfa7-0bd93d7d2a9b.png">
<img width="919" alt="Screen Shot 2022-08-23 at 3 29 59 PM" src="https://user-images.githubusercontent.com/45284810/186086943-827cef6d-0ed3-469b-8cc3-2f1f24b7c844.png">



### 스크린샷 (optional)
<img width="2555" alt="Screen Shot 2022-08-23 at 3 28 12 PM" src="https://user-images.githubusercontent.com/45284810/186087027-eaa53136-e6b8-4502-b401-64e52f8a10d4.png">

