### PR TITLE
HS-105 FEAT: delete single quote error handle in replace_dollar

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -128,6 +128,7 @@ int		get_single_quote_len(char *input_ptr);
 int		get_under_single_quote_len(char *input_ptr);
 int		get_under_dollar_len(char *input_ptr);
 char	*replace_whole_input_dollar(char *input);
+char	*replace_dollar_in_heredoc(char *input);
 
 /*		other			*/
 int		handle_quote(t_split *split, char *line);

--- a/src/utils/replace_dollar/replace_dollar.c
+++ b/src/utils/replace_dollar/replace_dollar.c
@@ -82,3 +82,19 @@ char	*replace_whole_input_dollar(char *input)
 	input = NULL;
 	return (input_buffer);
 }
+
+char	*replace_dollar_in_heredoc(char *input)
+{
+	char	*input_buffer;
+	char	*input_ptr;
+
+	if (!ft_strchr(input, '$'))
+		return (input);
+	input_buffer = safe_malloc(ft_strlen(input));
+	input_ptr = input;
+	input_buffer = append_buffer_under_dollar(input_buffer, input_ptr);
+	make_dollar_replaced_input(&input_buffer, &input_ptr);
+	free(input);
+	input = NULL;
+	return (input_buffer);
+}

--- a/src/utils/replace_dollar/replace_dollar.c
+++ b/src/utils/replace_dollar/replace_dollar.c
@@ -66,27 +66,11 @@ static void	make_dollar_replaced_input(\
 	}
 }
 
-int	is_not_single_quote_validate(char *input)
-{
-	int	cnt_single_quote;
-
-	cnt_single_quote = 0;
-	while (*input)
-	{
-		if (*input == '\'')
-			cnt_single_quote += 1;
-		input++;
-	}
-	return (cnt_single_quote % 2);
-}
-
 char	*replace_whole_input_dollar(char *input)
 {
 	char	*input_buffer;
 	char	*input_ptr;
 
-	if (is_not_single_quote_validate(input))
-		ft_error_exit("qoute parse error");
 	if (!ft_strchr(input, '$'))
 		return (input);
 	input_buffer = safe_malloc(ft_strlen(input));


### PR DESCRIPTION
### 요약
히어독에서는 ''가 예외처리가 아님.

`char	*replace_dollar_in_heredoc(char *input)`
위 함수를 이용해서 하시면 됩니다.

### 스크린샷 (optional)
<img width="390" alt="Screen Shot 2022-08-26 at 9 17 28 PM" src="https://user-images.githubusercontent.com/62806979/186902572-dff1be9e-f513-4bb6-bc70-fe948f26dc63.png">

