### PR TITLE
HS-118 FIX: signgle quote exist after replace

### DIFF
--- a/src/utils/replace_dollar/replace_dollar_append_utils.c
+++ b/src/utils/replace_dollar/replace_dollar_append_utils.c
@@ -59,7 +59,6 @@ char	*append_single_quote(char *input_buffer, char *input_ptr, int single_quote_
 	if (single_quote_len <= 0)
 		return (input_buffer);
 	new_input_buffer = safe_malloc(ft_strlen(input_buffer) + single_quote_len + 1);
-	input_ptr += 1;
 	ft_strlcpy(new_input_buffer, input_buffer, ft_strlen(input_buffer) + 1);
 	ft_strlcpy(new_input_buffer + ft_strlen(input_buffer), input_ptr, single_quote_len + 1);
 	free(input_buffer);

--- a/src/utils/replace_dollar/replace_dollar_len_utils.c
+++ b/src/utils/replace_dollar/replace_dollar_len_utils.c
@@ -33,7 +33,7 @@ int	get_env_len(char *str)
 int	get_single_quote_len(char *input_ptr)
 {
 	if (ft_strchr(input_ptr, '\''))
-		return (ft_strchr(input_ptr + 1, '\'') - ft_strchr(input_ptr, '\'') - 1);
+		return (ft_strchr(input_ptr + 1, '\'') - ft_strchr(input_ptr, '\'') + 1);
 	return (0);
 }
 

--- a/src/utils/replace_dollar/replace_dollar_utils.c
+++ b/src/utils/replace_dollar/replace_dollar_utils.c
@@ -38,7 +38,7 @@ void	r_handle_single_quote(char **input_buffer, char **input_ptr)
 		*input_buffer = \
 			append_single_quote(*input_buffer, *input_ptr, s_quote_len);
 		if (s_quote_len > 0)
-			*input_ptr += (s_quote_len + 2);
+			*input_ptr += (s_quote_len);
 	}
 }
 


### PR DESCRIPTION
### 요약
  <kdb>'</kbd> 가 치환후에도 사라지지 않습니다.

### 스크린샷 (optional)

<img width="778" alt="image" src="https://user-images.githubusercontent.com/62806979/187028280-2db901d0-8197-461a-adfd-e7ba0d48bcef.png">
