### PR TITLE
HS-115-minishell-tester-unset-and-ls

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -147,6 +147,7 @@ int		handle_quote(t_split *split, char *line);
 void	print_error_message(char *str);
 void	ft_error_exit(char *str);
 void	print_error_two_messages(char *str1, char *str2);
+void	ft_error_two_exit(char *str1, char *str2);
 t_env	*get_env_by_key(char *key);
 int		env_key_valid_checker(char *str);
 void	make_node_to_envp();

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -8,7 +8,7 @@ void	execute_command(t_process *process)
 	if (is_accessable_command(process->cmd_line, g_minishell_info.ps_list->paths))
 		command = get_accessable_command(process->cmd_line, g_minishell_info.ps_list->paths);
 	else
-		ft_error_exit("command not found");
+		ft_error_two_exit("command not found: ", *process->argv);
 	execve(command, process->argv, process->envp);
 	exit(EXIT_FAILURE);
 }

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -8,7 +8,7 @@ void	execute_command(t_process *process)
 	if (is_accessable_command(process->cmd_line, g_minishell_info.ps_list->paths))
 		command = get_accessable_command(process->cmd_line, g_minishell_info.ps_list->paths);
 	else
-		ft_error_two_exit("command not found: ", *process->argv);
+		ft_error_two_exit(*process->argv, ": No Such file or directory");
 	execve(command, process->argv, process->envp);
 	exit(EXIT_FAILURE);
 }

--- a/src/executor/is_func.c
+++ b/src/executor/is_func.c
@@ -21,7 +21,7 @@ char	*get_accessable_command(t_token *cmd_list, char **paths)
 	if (!access(command, 0))
 		return (ft_strdup(command));
 	if (paths == NULL)
-		ft_error_exit("I will Find You.. and I will Kill you");
+		return (NULL);
 	while (*paths)
 	{
 		tmp = ft_strjoin(*paths, "/");
@@ -34,8 +34,7 @@ char	*get_accessable_command(t_token *cmd_list, char **paths)
 		path_command = NULL;
 		paths++;
 	}
-	ft_error_exit(ft_strjoin(": command not found", command));
-	return (0);
+	return (NULL);
 }
 
 int	is_accessable_command(t_token *cmd_list, char **paths)

--- a/src/init.c
+++ b/src/init.c
@@ -26,7 +26,6 @@ void	init_minishell(void)
 				make_node_to_envp();
 				executor();
 				free_all();
-				
 			}
 		}
 		else

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,9 @@ void	init_minishell_info(void)
 	init_pipe(&g_minishell_info.pipes);
 	g_minishell_info.ps_list = NULL;
 	g_minishell_info.heredoc_cnt = 0;
+	g_minishell_info.ft_stdin = dup(STDIN_FILENO);
+	g_minishell_info.ft_stdout = dup(STDOUT_FILENO);
+	g_minishell_info.ft_stderr = dup(STDERR_FILENO);
 }
 
 int	main(int ac, char **av, char **env)
@@ -16,9 +19,6 @@ int	main(int ac, char **av, char **env)
 	print_wallpaper();
 	init_minishell_info();
 	env_linked_list(env);
-	g_minishell_info.ft_stdin = dup(STDIN_FILENO);
-	g_minishell_info.ft_stdout = dup(STDOUT_FILENO);
-	g_minishell_info.ft_stderr = dup(STDERR_FILENO);
 	init_minishell();
 	return (0);
 }

--- a/src/utils/ft_error.c
+++ b/src/utils/ft_error.c
@@ -13,6 +13,13 @@ void	ft_error_exit(char *str)
     exit(EXIT_FAILURE);
 }
 
+void	ft_error_two_exit(char *str1, char *str2)
+{
+	print_error_two_messages(str1, str2);
+    exit(EXIT_FAILURE);
+}
+
+
 void	print_error_two_messages(char *str1, char *str2)
 {
 	write(2, RED, ft_strlen(RED));


### PR DESCRIPTION
### 요약
```unset PATH``` 실행 후 명령어 실행 시
에러 메세지가 나와야 하는데 안나왔음.
### 작업 사항
paths 가 없을 때 내장함수 실행 시 에러처리
에러 메세지 bash 와 똑같이 변경
### 스크린샷
<img width="946" alt="Screen Shot 2022-08-27 at 8 52 49 PM" src="https://user-images.githubusercontent.com/45284810/187029023-ff75febf-ae7d-49df-bbbe-ed712a09987d.png">

