### PR TITLE
HS-124-unset-return-error

### DIFF
--- a/src/built_in/ft_unset.c
+++ b/src/built_in/ft_unset.c
@@ -26,15 +26,15 @@ static void	unsetting(t_list *env_list, t_token *token)
 	}
 }
 
-static int	unset_have_no_parm(t_token *token)
+static int	unset_have_no_param(t_token *token)
 {
 	if (token->next == NULL)
 	{
 		token = token->next;
-		return (1);
+		return (TRUE);
 	}
 	token = token->next;
-	return (0);
+	return (FALSE);
 }
 
 int	ft_unset(void)
@@ -44,7 +44,7 @@ int	ft_unset(void)
 
 	env_list = g_minishell_info.env_list;
 	token = g_minishell_info.ps_list->cmd_line;
-	if (unset_have_no_parm(token))
+	if (unset_have_no_param(token))
 		return (EXIT_FAILURE);
 	token = token->next;
 	while (token)


### PR DESCRIPTION
### 요약
unset 만 입력하고 인자가 없을 때 1이 아닌 0을 리턴

### 작업 사항
- TRUE, FALSE 로 변경
- 함수명 살짜쿵 변경