### PR TITLE
Hs 124 unset return error

### DIFF
--- a/src/built_in/ft_unset.c
+++ b/src/built_in/ft_unset.c
@@ -26,17 +26,6 @@ static void	unsetting(t_list *env_list, t_token *token)
 	}
 }
 
-static int	unset_have_no_param(t_token *token)
-{
-	if (token->next == NULL)
-	{
-		token = token->next;
-		return (TRUE);
-	}
-	token = token->next;
-	return (FALSE);
-}
-
 int	ft_unset(void)
 {
 	t_list	*env_list;
@@ -44,8 +33,6 @@ int	ft_unset(void)
 
 	env_list = g_minishell_info.env_list;
 	token = g_minishell_info.ps_list->cmd_line;
-	if (unset_have_no_param(token))
-		return (EXIT_FAILURE);
 	token = token->next;
 	while (token)
 	{

--- a/src/built_in/ft_unset.c
+++ b/src/built_in/ft_unset.c
@@ -26,15 +26,15 @@ static void	unsetting(t_list *env_list, t_token *token)
 	}
 }
 
-static int	unset_have_no_parm(t_token *token)
+static int	unset_have_no_param(t_token *token)
 {
 	if (token->next == NULL)
 	{
 		token = token->next;
-		return (1);
+		return (TRUE);
 	}
 	token = token->next;
-	return (0);
+	return (FALSE);
 }
 
 int	ft_unset(void)
@@ -44,7 +44,7 @@ int	ft_unset(void)
 
 	env_list = g_minishell_info.env_list;
 	token = g_minishell_info.ps_list->cmd_line;
-	if (unset_have_no_parm(token))
+	if (unset_have_no_param(token))
 		return (EXIT_FAILURE);
 	token = token->next;
 	while (token)


### PR DESCRIPTION
### 요약
unset 종료 상태값 수정

### 작업 사항
* bash에서 unset 만 입력할 경우 정상 종료로 받음
  즉, 파라미터가 없을 때 정상 종료가 되는 것. no_param 함수가 없어도 되기 때문에 제거함

### 스크린샷 (optional)
![image](https://user-images.githubusercontent.com/85930183/187053901-d079d6a9-33d6-4c2a-a0bf-3fd826d16dbe.png)
