### PR TITLE
HS-125 FIX: echo 에러 처리 (프로세스 argv를 매개변수로 받음)

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -88,9 +88,9 @@ int	ft_pwd(void);
 int	ft_env(void);
 int	ft_cd(void);
 int	ft_unset(void);
-int	ft_export(t_token *cmd_line);
 int	ft_exit(void);
-int	ft_echo(void);
+int	ft_echo(char **argv);
+int	ft_export(t_token *cmd_line);
 
 /* utils */
 /* built-in */

--- a/src/built_in/ft_echo.c
+++ b/src/built_in/ft_echo.c
@@ -1,13 +1,11 @@
 #include "../../include/minishell.h"
 
-static void	print_arg_with_idx(int idx)
+static void	print_arg_with_idx(char **argv, int idx)
 {
 	int		flag;
-	char	**argv;
 
 	flag = 0;
 	flag = idx;
-	argv = g_minishell_info.ps_list->argv;
 	while (argv[idx])
 	{
 		ft_putstr_fd(argv[idx], 1);
@@ -19,12 +17,10 @@ static void	print_arg_with_idx(int idx)
 		ft_putchar_fd('\n', 1);
 }
 
-static void	check_option_and_find_print_position(int *idx)
+static void	check_option_and_find_print_position(char **argv, int *idx)
 {
 	int		i;
-	char	**argv;
 
-	argv = g_minishell_info.ps_list->argv;
 	while (argv[*idx])
 	{
 		i = 0;
@@ -42,12 +38,12 @@ static void	check_option_and_find_print_position(int *idx)
 	}
 }
 
-int	ft_echo(void)
+int	ft_echo(char **argv)
 {
 	int		idx;
 
 	idx = 1;
-	check_option_and_find_print_position(&idx);
-	print_arg_with_idx(idx);
+	check_option_and_find_print_position(argv, &idx);
+	print_arg_with_idx(argv, idx);
 	return (EXIT_SUCCESS);
 }

--- a/src/utils/built_in_utils/execute_built_in.c
+++ b/src/utils/built_in_utils/execute_built_in.c
@@ -41,6 +41,6 @@ int execute_built_in(t_process *process)
 	else if (is_same_string(cmd, UNSET))
 		return (ft_unset());
 	else if (is_same_string(cmd, ECHO))
-		return (ft_echo());
+		return (ft_echo(process->argv));
 	return (EXIT_FAILURE);
 }


### PR DESCRIPTION
### 요약
ls | echo a 를 하면 a 출력이 안됐었음.
프로세스에 맞는 argv 를 가져와야하는데, ft_echo 에 매개변수가 없었음.

### 작업 사항
ft_echo 에 argv 매개변수로 추가

### 스크린샷 (optional)
<img width="838" alt="image" src="https://user-images.githubusercontent.com/85930183/187054405-8819b672-a347-4bee-87ad-d5efa3ca7b79.png">
